### PR TITLE
fix: monitorProbes bug

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -175,7 +175,7 @@ export const HealthPlugin: Plugin<Partial<HealthPluginOptions>> = {
         path: config.livenessRoute,
         options: {
           plugins: {
-            HealthPlugin: monitorProbes
+            [pkg.name]: monitorProbes
           },
           auth: getAuth(config, 'liveness')
         },
@@ -195,7 +195,7 @@ export const HealthPlugin: Plugin<Partial<HealthPluginOptions>> = {
         path: config.readinessRoute,
         options: {
           plugins: {
-            HealthPlugin: monitorProbes
+            [pkg.name]: monitorProbes
           },
           auth: getAuth(config, 'readiness')
         },


### PR DESCRIPTION
the conf for monitorProbes use HealthPlugin as key instead of pkg.name.
So readiness route and liveness route are always monitored